### PR TITLE
[Silver 3] 1783번 병든 나이트

### DIFF
--- a/src/greedy/greedy_01783_sickKnight.java
+++ b/src/greedy/greedy_01783_sickKnight.java
@@ -1,0 +1,38 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1783
+ */
+public class greedy_01783_sickKnight {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        if (N == 1) {
+            bw.write("1");
+        } else if (N == 2) {
+            bw.write(Math.min(4, (M + 1) / 2) + "");
+        } else {
+            if (M < 7) {
+                bw.write(Math.min(4, M) + "");
+            } else {
+                bw.write((M - 7 + 5) + "");
+            }
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
### [1783번 병든 나이트](https://www.acmicpc.net/problem/1783)

#### 1. 풀이

**1) 나이트의 움직임**
 해당 문제에서 첫 번째로 체크해야 할 것은 바로 `병든 나이트`의 움직임이다. 나이트가 아래 이미지 기준, (2, 0)의 위치에서 출발했다고 가정해보면 다음과 같은 위치들로 움직일 수 있다. 즉, 좌측으로 움직일 수 없음을 알 수 있고 다시 말해 우측으로 전진만 할 수 있다는 것이다.

![image](https://user-images.githubusercontent.com/44356083/201451172-e34e0523-8ccf-4e1a-9ee3-28287d17349a.png)

**2) 이동방법의 제약**
  나이트가 4번 이상 움직이기 위해서는 위 이미지에서 볼 수 있는 움직임을 모두 한 번 씩 사용해야만 한다. 4번 미만으로 움직일 때는 어떠한 방법을 채택하더라도 무방하다. 즉, 4번 이상 움직이기(방문한 칸이 5개 이상) 위해서는 최소 아래의 조건을 만족해야 한다.

 - N(높이) >= 3
 - M(너비) >= 7

![image](https://user-images.githubusercontent.com/44356083/201451542-37f81de8-4af9-41c6-9ecb-309525a4adb7.png)

**3) 해 도출**
 위 조건들에 따라 몇 가지 분기 처리를 진행할 수 있다.

1. 높이가 1인 경우
  - 처음 나이트를 놓는 한 가지 경우밖에 없다.
 
2. 높이가 2인 경우
  - 위, 아래 한 칸씩 최대 3번을 움직이는 경우밖에 없다.

3. 높이가 3이상인 경우
 - 너비에 따라서 결과값이 달라지는데, 너비가 7이상인 경우부터는 아래 이미지가 가장 효율적인 움직임이므로 높이는 더 이상 중요한 factor가 아니게 된다.
![image](https://user-images.githubusercontent.com/44356083/201452045-f0f1bae0-814b-4e06-92c3-5aed8e578363.png)

