### PR TITLE
[Gold 5] 1461번 도서관

### DIFF
--- a/src/greedy/greedy_01461_library.java
+++ b/src/greedy/greedy_01461_library.java
@@ -1,0 +1,57 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1461
+ */
+public class greedy_01461_library {
+
+    static int findZeroIndex(int[] arr) {
+        for (int i = 0, n = arr.length; i < n; i++) {
+            if (arr[i] == 0) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+
+        int[] arr = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(arr);
+
+        int zeroIdx = findZeroIndex(arr);
+        int ans = 0;
+        for (int i = 0; i < zeroIdx; i += M) {
+            ans += Math.abs(arr[i] * 2);
+        }
+
+        for (int i = N; i > zeroIdx; i -= M) {
+            ans += arr[i] * 2;
+        }
+
+        ans -= Math.max(Math.abs(arr[0]), Math.abs(arr[N]));
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
### [1461번 도서관](https://www.acmicpc.net/problem/1461)

#### 1. 풀이
 좌표 0을 기준으로 양 방향으로 책들이 존재할 수 있으며, 한 번에 M권의 책을 들고 움직일 수 있다. 그렇다면 어떤 경우에 가장 효과적인 움직임을 가져갈 수 있을까?

**1. 방향**
 움직임은 단일 방향으로만 가져가는 것이 이득이다. 아래의 예시를 통해 살펴 보자.

```text
-(N + 1) -N 0 N N + 1
```

반납장소가 위와 같이 지정되어 있고 두 권씩 들고 움직일 수 있으며 마지막 책을 반납하고 돌아온다는 가정을 했을 때, 단일 방향 + 양쪽 방향으로 움직인다고 가정해보자.
 - 단일방향 : `(N + 1) * 2 + (N + 1) * 2`
 - 양방향 : `(N * 2) * 2 + (N + 1) * 2`  or `(N + 1 + N) * 2 + (N + 1 + N) * 2`
 
> 단일방향이 압도적으로 이득이다.

**2. 마지막 반납경로의 설정**
 가장 멀리 있는 반납 장소를 책을 최대한 많이 들고 마지막에 가는 것이 이득이다. 마지막 장소에서는 돌아오지 않아도 되기 때문이다.

#### 2. 예제 입력 1
```text
7 2
-37 2 -6 -39 -29 11 -28
```

입력받은 반납장소의 배열에 0(기준점)을 추가하여 정렬한 뒤, 양 방향으로 바깥에서부터 M 개씩 부분 집합을 생성한다. 남는 것은 남은 것 대로 집합을 형성한다.

```text
{-39 -37} {-29 -28} {-6} 0 {2 11}
```

각 부분집합의 요소들의 절대값중 MAX 값에 2를 곱하여 모두 더해준다.

이 경우에는 마지막 책도 반납처리가 되었으므로, 전체 배열에서 가장 큰 절대값을 1회 제거해주면 최소 이동 거리를 만들 수 있게 된다.

```text
{**-39** -37} {**-29** -28} {**-6**} 0 {2 **11**}
```

정답 : (39 * 2) + (29 * 2) + (6 * 2) + (11 * 2) - 39 = 131