### PR TITLE
[Gold 3] 2109번 순회강연

### DIFF
--- a/src/greedy/greedy_02109_lectureTour.java
+++ b/src/greedy/greedy_02109_lectureTour.java
@@ -1,0 +1,63 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/2109
+ */
+public class greedy_02109_lectureTour {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Lecture> pq = new PriorityQueue<>();
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            pq.add(new Lecture(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())));
+        }
+
+        boolean[] days = new boolean[10001];
+        int tot = 0;
+        while (!pq.isEmpty()) {
+            Lecture lec = pq.poll();
+            for (int day = lec.day; day >= 1; day--) {
+                if (days[day]) continue;
+
+                days[day] = true;
+                tot += lec.pay;
+                break;
+            }
+        }
+
+        bw.write(tot + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static class Lecture implements Comparable<Lecture> {
+        int pay;
+        int day;
+
+        public Lecture(int pay, int day) {
+            this.pay = pay;
+            this.day = day;
+        }
+
+        @Override
+        public int compareTo(Lecture a) {
+            if (a.pay == this.pay) {
+                return a.day - this.day;
+            }
+            return a.pay - this.pay;
+        }
+    }
+}


### PR DESCRIPTION
## [2109번 순회강연](https://www.acmicpc.net/problem/2109)

### 1. 풀이
 `가장 많은 돈을 벌 수 있는` 스케줄을 작성하는 것은 `가장 많은 회의를 열어보자`라는 회의실 배정문제와 유사하다고 볼 수 있다. 다만 차이점이자 현재 문제의 핵심인 `d`일 안에 와서 강연을 하면 된다는 조건이다. 받을 수 있는 보수가 높은 강연을 최대한 많이 배치하는 것이 결국 문제의 요점이 될 것이다.

> 그럼 어떻게?

앞서 언급한 두 가지 핵심 조건들로 입력받은 강연의 목록을 정렬할 기준을 세워본다.

**1. 강연료 내림차순**
 하루에 단 하나의 강연만을 진행할 수 있으므로, 가장 강연료가 비싼 강연들을 먼저 배치하는 것이 이득이다.

**2. 날짜 내림차순**
 같은 강연료라 하더라도, __나중에 배치할 수 있는 강연이 있다면 나중에 배치__ 하는 것이 이득이다. 앞에 배치한다면 강연료에서 손해를 보기 때문이다.

이를 기반으로 input으로 받은 강연목록을 정렬하고 순회를 진행하는데, 각 강연의 날짜에서 역순으로 올라가며 강연을 배치할 수 있는 날에 배치하면 문제를 풀 수 있다!

### 2. 추가 예제 입력

문제에는 없으나, 풀이를 위해 고민했던 추가 테스트 케이스를 기재해두고자 한다.

```text
input

3
100 3
100 2
120 3

output
320
```

