### PR TITLE
[Gold 5] 1041번 주사위

### DIFF
--- a/src/greedy/greedy_01041_dice.java
+++ b/src/greedy/greedy_01041_dice.java
@@ -1,0 +1,102 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+
+public class greedy_01041_dice {
+
+    public static final long MAX_NUMBER_FLAG = 51L;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        Dice dice = new Dice(convertLineToLongArray(br.readLine()));
+
+        if (N == 1) {
+            bw.write(dice.oneDice() + "");
+        } else {
+            long sum = dice.getMinOne() * (N - 2) * (5 * N - 6)
+                    + dice.getMinTwo() * 4 * (2 * N - 3)
+                    + dice.getMinThree() * 4;
+            bw.write(sum + "");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static long[] convertLineToLongArray(String line) {
+        return Arrays.stream(line.split(" "))
+                .mapToLong(Long::parseLong)
+                .toArray();
+    }
+
+    private static class Dice {
+        private final long[] dice;
+        private final long minOne;
+        private final long minTwo;
+        private final long minThree;
+
+        public Dice(long[] arr) {
+            this.dice = arr;
+            this.minOne = calculateMinOne(arr);
+            this.minTwo = calculateMinTwo(arr);
+            this.minThree = calculateMinThree(arr);
+        }
+
+        public long oneDice() {
+            long sum = 0L;
+            long max = 0L;
+            for (int i = 0; i < 6; i++) {
+                sum += dice[i];
+                max = Math.max(max, dice[i]);
+            }
+            return sum - max;
+        }
+
+        public long getMinOne() {
+            return minOne;
+        }
+
+        public long getMinTwo() {
+            return minTwo;
+        }
+
+        public long getMinThree() {
+            return minThree;
+        }
+
+        private long calculateMinOne(long[] arr) {
+            return Arrays.stream(arr)
+                    .min()
+                    .getAsLong();
+        }
+
+        private long calculateMinTwo(long[] arr) {
+            long min = MAX_NUMBER_FLAG * 2;
+            for (int i = 0; i < 6; i++) {
+                for (int j = i + 1; j < 6; j++) {
+                    if (j != 5 - i) {
+                        min = Math.min(min, arr[i] + arr[j]);
+                    }
+                }
+            }
+            return min;
+        }
+
+        private long calculateMinThree(long[] dice) {
+            long min = MAX_NUMBER_FLAG * 3;
+            long temp[] = {dice[0]+dice[1]+dice[2], dice[0]+dice[1]+dice[3], dice[0]+dice[2]+dice[4], dice[0]+dice[3]+dice[4], dice[1]+dice[2]+dice[5], dice[1]+dice[3]+dice[5], dice[2]+dice[4]+dice[5], dice[3]+dice[4]+dice[5]};
+            for (int i = 0; i < 8; i++) {
+                min = Math.min(min, temp[i]);
+            }
+            return min;
+        }
+    }
+}


### PR DESCRIPTION
## [1041번 주사위](https://www.acmicpc.net/problem/1041)

### 1. 풀이
 단일 주사위로 N x N x N 크기의 정육면체를 만들었을 때, 밑면을 제외한 면에 노출되는 숫자가 최소가 되게 만드는 문제다. 이 문제가 `Greedy`로 분류되어 있는 이유는 정육면체를 만들었을 때, 노출되는 면을 항상 최선의 선택을 할 수 있기 때문인데 어떻게 보면 `Simulation`에 가까운 문제 유형이라고 볼 수도 있겠다.

 정육면체를 만드는 것을 어떻게 작은 문제로 나누어서 생각해 볼 수 있을까? 아래 이미지를 참고하자.

![image](https://user-images.githubusercontent.com/44356083/201550298-c0e854c2-3155-4612-bdd1-b53315baaa87.png)

큐브를 생각해보면 그 답을 빠르게 떠올릴 수 있는데, 큐브를 쌓았을 때 외부에 노출되는 면적은 위 이미지에서와 같이 '한 면', '두 면', '세 면'이 노출되는 문제로 나누어서 생각해 볼 수 있다. 단, 1 x 1 x 1 사이즈를 만들 때는 한 주사위의 '다섯 면'이 노출되게 된다. 

따라서 주어진 주사위의 전개도를 기반으로 '한 면', '두 면', '세 면'의 최소값을 미리 설정해두고, N x N x N 정육면체에서 각 면이 노출되는 개수를 점화식을 세운 다음에 더해주면 끝나는 문제였다.

해당 문제가 조금 더 재밋기 위해서는 여러 개의 주사위가 주어지는 방법도 있었을 것이다.

---
### 1) 면 종류 별 개수

**1.1) 한 면: (N - 2) * (5 * N - 6)** 

한 면이 노출되는 주사위의 경우, 가장 위층을 제외하고는 (N - 2) * 4 개 만큼 등장하며, 가장 위층에는 (N - 2) * (N - 2)개 만큼 등장하게 된다.

`4 * (N-2) * (N - 1) + (N - 2) * (N - 2) = (N - 2) * (4 * (N - 1) + (N - 2)) = (N - 2) * (5N - 6)`

![image](https://user-images.githubusercontent.com/44356083/201551331-d70106c9-751c-4f5d-a6d3-72e98f02d541.png)

**1.2) 두 면: 4 * (2 * N - 3)**

두 면이 노출되는 주사위의 경우, 가장 위층을 제외하고는 4개씩 등장하며 가장 위층에서는 (N - 2) * 4 개 만큼 등장하게 된다.
`(N - 1) * 4 + (N - 2) * 4  = 4N - 4 + 4N -8 = 4 * (2N - 3)`

![image](https://user-images.githubusercontent.com/44356083/201550918-e79269aa-de1d-4096-b2af-79b1bf335dd4.png)

**1.3) 세 면: 4**
 N 값과 무방하게 정육면체의 위쪽 네 꼭지점에 해당한다.
