### PR TITLE
[Gold 2] 1135번 뉴스 전하기

### DIFF
--- a/src/greedy/greedy_01135_transferNews.java
+++ b/src/greedy/greedy_01135_transferNews.java
@@ -1,0 +1,63 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1135
+ */
+public class greedy_01135_transferNews {
+
+    static List<Integer>[] adj;
+
+    static int solve(int node) {
+        if (adj[node].isEmpty()) {
+            return 0;
+        }
+
+        int length = adj[node].size();
+        Integer[] subMemo = new Integer[length];
+        for (int i = 0; i < length; i++) {
+            subMemo[i] = solve(adj[node].get(i));
+        }
+
+        Arrays.sort(subMemo, Collections.reverseOrder());
+
+        int ret = 0;
+        for (int i = 0; i < length; i++) {
+            ret = Math.max(ret, subMemo[i] + (i + 1));
+        }
+        return ret;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+
+        adj = new List[N];
+        for (int i = 0; i < N; i++) {
+            adj[i] = new ArrayList<>();
+        }
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            int parentNode = Integer.parseInt(st.nextToken());
+            if (parentNode == -1) continue;
+            adj[parentNode].add(i);
+        }
+
+        bw.write(solve(0) + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## [1135번 뉴스 전하기](https://www.acmicpc.net/problem/1135)

### 1. 풀이
 모든 사람은 본인의 직속부하에게 한 번에 한 사람씩 뉴스를 전할 수 있는데, 이 말인 즉슨 뉴스를 전달하는 것이 병렬로 진행되고 있음을 의미한다. 말보다는 그림으로 간단하게 보자.

![image](https://user-images.githubusercontent.com/44356083/201909883-87fc363d-56e8-49e3-b0ca-b7b68a8a0c67.png)

원 안의 숫자는 노드의 번호를, 빨간 숫자는 가장 적은 시간으로 뉴스를 전달하는 순서다.

이 때, 병렬로 전달한다는 것은 `0 -> 1`로 첫 번째 뉴스가 전달되고 나면, `1 -> 3`, `0 -> 2` 이렇게 같은 시간에 두 번의 전달이 이루어질 수 있다는 것을 의미한다.

그렇다면 우리는 직관적으로 병렬연산에서 최대한의 효율을 뽑아내기 위해서는, 직속 부하에게 뉴스를 전달하는데 가장 오래 걸리는 부하에게 먼저 뉴스를 전달해야 한다는 것을 알 수 있다.

---
그렇다면 뉴스를 전달하는 순서는 정해졌고, 시간은 어떻게 계산할 수 있을까? 먼저 아래 그림을 보자.

![image](https://user-images.githubusercontent.com/44356083/201910859-d58d01a8-ce8f-4179-a20d-5dfd85e930a8.png)

1번 노드와 2번 노드 모두 자식 노드에게 뉴스를 전달하는 시간이 1로 똑같기 때문에, 0번 노드에서 자식 노드에게 전달하는 시간 1을 더해서 정답이 2라고 생각할 수 있다(~사실 필자가 처음에 그랬다~). 오랜 시간 삽질을 한 끝에 0번 노드가 1번 노드에 먼저 뉴스를 전달하는 것은 자명함으로 1을 더하는 것이 맞지만, 2번 노드에는 두 번째로 전달하기 때문에 2를 더해줘야 하는 것이었다.

정리하자면, 모든 자식에게 뉴스를 전달하는 시간은 각 자식노드별로 `(자식노드가 모든 뉴스를 전달하는 시간) + (자식 노드에게 도달하는 시간)`을 구해서 그 중 최대값을 고르면 되는 것이다.

---
이러한 풀이방법의 매커니즘에 따라서 해당 문제는 크게 두 가지 테크닉을 필요로 한다.

1. **Greedy**  : 어떤 자식노드에게 먼저 뉴스를 전달할지 결정하는 매커니즘
2. **DFS** : 각각의 자식노드 별로 뉴스를 전달하는 시간을 미리 체크해야 함으로 'DFS(깊이 우선 탐색)'을 진행해야 한다.