### PR TITLE
[Gold 3] 2812번 크게 만들기

### DIFF
--- a/src/greedy/greedy_02812_makeBigger.java
+++ b/src/greedy/greedy_02812_makeBigger.java
@@ -1,0 +1,52 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/2812
+ */
+public class greedy_02812_makeBigger {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        String line = br.readLine();
+        LinkedList<Integer> stack = new LinkedList<>();
+        for (int i = 0; i < N; i++) {
+            int n = line.charAt(i) - '0';
+            if (stack.isEmpty() || K == 0) {
+                stack.addLast(n);
+                continue;
+            }
+
+            while (!stack.isEmpty() && stack.peekLast() < n && K > 0) {
+                stack.removeLast();
+                K--;
+            }
+
+            stack.addLast(n);
+        }
+
+        while (K > 0) {
+            stack.removeLast();
+            K--;
+        }
+
+        while (!stack.isEmpty()) {
+            bw.write(stack.pollFirst() + "");
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## [2812번 ](https://www.acmicpc.net/problem/2812)

### 1. 풀이
주어진 N자리 숫자에서 K개를 지워서 가장 큰 수를 만들기 위해서는 되도록 앞에서 부터 작은 숫자를 제거하는 것이 이득이다. 다만 인풋을 받아 모든 경우의 수를 따져보면 `2^N` 개만큼 풀어봐야 하므로, 시간 내에 풀이할 수가 없다. 그렇다면 앞에서부터 작은 숫자를 제거하는 것에 초점을 맞춰서 풀이할 수 있다.

주어진 숫자를 처음부터 차례대로 순환하면서 진행을 하며 숫자를 차례대로 스택에 채워 넣는다. 단, 스택에 숫자를 넣기 전에 해당 숫자보다 작은 숫자가 스택의 `top`에 위치한다면 반복적으로 제거해 주는 작업을 수행한다. 되도록이면 앞에서 작은 숫자를 제거하는 것이 더 큰 숫자를 만들 수 있다는 것은 자명하기 때문이다.

`Stack`을 이용하고 `StringBuilder`의 `reverse`를 이용해 출력해도 되지만, 불필요한 연산을 줄이기 위해서 일종의 `Deque`와 같이 동작할 수 있는 `LinkedList`를 사용하였다.