### PR TITLE
[Gold 2] 1781번 컵라면

### DIFF
--- a/src/greedy/greedy_01781_cupNoodle.java
+++ b/src/greedy/greedy_01781_cupNoodle.java
@@ -1,0 +1,63 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1781
+ */
+public class greedy_01781_cupNoodle {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+
+        PriorityQueue<Problem> pq = new PriorityQueue<>();
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            pq.add(new Problem(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())));
+        }
+
+        boolean[] check = new boolean[N + 1];
+        long tot = 0L;
+        while (!pq.isEmpty()) {
+            Problem p = pq.poll();
+            for (int i = p.deadline; i >= 1; i--) {
+                if (!check[i]) {
+                    check[i] = true;
+                    tot += p.cnt;
+                    break;
+                }
+            }
+        }
+        bw.write(tot + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    private static class Problem implements Comparable<Problem> {
+        int deadline;
+        int cnt;
+
+        public Problem(int deadline, int cnt) {
+            this.deadline = deadline;
+            this.cnt = cnt;
+        }
+
+        @Override
+        public int compareTo(Problem o) {
+            if (o.cnt == this.cnt) {
+                return o.deadline - this.deadline;
+            }
+            return o.cnt - this.cnt;
+        }
+    }
+
+}


### PR DESCRIPTION
## [1781번 컵라면](https://www.acmicpc.net/problem/1781)

### 1. 풀이
해당 문제는 #5 와 풀이에서 맥락을 같이 한다. 최대한 많은 컵라면을 받기 위해서는 컵라면을 가장 많이 주는 문제를 데드라인 이내에 푸는 것이 무조건 이득이므로, 컵라면 순으로 내림차순 정렬을 하되 데드라인 기준으로 내림차순으로 정렬한다. 

같은 양의 컵라면을 제공하는 문제라면, 데드라인이 긴 것을 나중에 푸는 것이 두 문제 모두 풀이할 수 있으므로 이득이기 때문이다. 따라서, 위에서 언급한 기준으로 정렬하고 순차적으로 데드라인 내에 문제를 배치하여 가장 많은 컵라면을 받을 수 있는 경우를 체크한다.

[2109번 순회강연](https://www.acmicpc.net/problem/2109)의 경우와 마찬가지로 우선순위 큐를 이용해 문제를 풀이하였다.