### PR TITLE
[Gold 1] 1285번 동전 뒤집기

### DIFF
--- a/src/greedy/greedy_01285_flipCoin.java
+++ b/src/greedy/greedy_01285_flipCoin.java
@@ -1,0 +1,52 @@
+package greedy;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1285
+ */
+public class greedy_01285_flipCoin {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        int[][] map = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < N; j++) {
+                map[i][j] = line.charAt(j) == 'T' ? 1 : 0;
+            }
+        }
+
+        int ans = N * N;
+        for (int idx = 0, n = (1 << N) - 1; idx < n; idx++) {
+            int tot = 0;
+
+            for (int x = 0; x < N; x++) {
+                int temp = 0;
+                for (int y = 0; y < N; y++) {
+                    int current = map[y][x];
+                    if ((idx & (1 << y)) != 0) {
+                        current = map[y][x] ^ 1;
+                    }
+                    if (current == 1) {
+                        temp++;
+                    }
+                }
+                tot += Math.min(temp, N - temp);
+            }
+
+            ans = Math.min(ans, tot);
+        }
+
+        bw.write(ans + "");
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## [1285번 동전 뒤집기](https://www.acmicpc.net/problem/1285)

### 1. 풀이
 문제에서 동전을 뒤집을 수 있는 방법은 행, 혹은 열 전체의 동전을 한 번에 뒤집는 것이라고 얘기하고 있다. 뒤집을 수 있는 횟수에 제약은 없으며, 단일 동전을 뒤집는 것이 아니므로 각 행/열을 뒤집어 봄으로써 어떤 경우에 뒷면의 수를 가장 적게 만들 수 있는가를 확인해봐야 한다.

---
**1. 동전을 행/열 단위로 뒤집는 행동을 어떻게 정의할 것인가?**
 `N x N` 사이즈이므로 한 변의 길이는 N이다. 그렇다면 한 변 즉, 행 혹은 열을 기준으로 동전을 뒤집을 수 있는 경우의 수는 2ⁿ개다. N이 3이라고 가정했을 때 아래 경우의 수를 살펴보자

> Φ, (1), (2), (3), (1, 2), (1, 3), (2, 3), (1, 2, 3)

위 모든 경우의 수를 순회하면서 진행할 때, 특정 행 혹은 열이 뒤집어 졌는지 아닌지를 탐지할 수 있는 가장 좋은 방법은 무엇일까? 바로 `비트마스크`이다. (비트마스크는 [다음 포스트](https://kwanik.tistory.com/3)를 참고하자.) 길이 N에 대한 모든 경우의 수를 나타내기 위해서는 N자리 비트만 있으면 되는데, 위 경우의 수를 비트로 표기하면 아래와 같아 진다(괄호 안은 10진수)

> 000, 001(1), 010(2), 100(4), 011(3), 101(5), 110(6), 111(7)

---
**2. 뒤집는 행동이 정의되었다면 최선의 답은 어떻게 구할 것인가?**
 변을 모두 뒤집어보는 경우의 수를 따지는 것은 각 행/열 중 하나만 선택해서 진행하면 된다. 만약 행 기준으로 순회를 하고 있다면, 해당 행에서 열을 뒤집을지 말지를 판단해서 뒷면이 가장 적은 경우의 수를 답으로 채택하면 된다. 이 때, 별도의 순회과정은 필요로 하지 않는다. 왜냐하면 만약 1열의 뒷면이 `1 개`라면 열을 뒤집지 않으면 `1 개`의 뒷면일 것이고, 뒤집는다면 `N - 1 = 2`개의 뒷면일 것이므로, 뒤집지 않는 것이 이득이라고 판단 내릴 수 있게 된다.

---
위 메커니즘을 가지고 구현한 내용은 코드를 참고하자.