### PR TITLE
[Silver 3] 6580번 쿼드 트리

### DIFF
--- a/src/divideNConquer/dnc_06580_quadTree.java
+++ b/src/divideNConquer/dnc_06580_quadTree.java
@@ -1,0 +1,83 @@
+package divideNConquer;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/6580
+ */
+public class dnc_06580_quadTree {
+
+    static boolean[][] map;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine().split(" ")[2]);
+        map = new boolean[N][N];
+
+        callUnusableLine(br, 2);
+
+        for (int i = 0; i < N; i++) {
+            String[] input = br.readLine().split(",");
+            for (int j = 0; j < N / 8; j++) {
+                setUpMapByHexCode(input[j], i, j * 8);
+            }
+        }
+
+        callUnusableLine(br, 1);
+
+        bw.write(N + "\n");
+        write(bw, 0, 0, N);
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static void write(BufferedWriter bw, int row, int col, int size) throws IOException {
+        boolean flag = true;
+        for (int i = row; i < row + size; i++) {
+            for (int j = col; j < col + size; j++) {
+                if (map[row][col] != map[i][j]) {
+                    flag = false;
+                    break;
+                }
+            }
+        }
+
+        if (flag) {
+            bw.write(map[row][col] ? "B" : "W");
+        } else {
+            bw.write("Q");
+            size >>= 1;
+            write(bw, row, col, size);
+            write(bw, row, col + size, size);
+            write(bw, row + size, col, size);
+            write(bw, row + size, col + size, size);
+        }
+    }
+
+    static void setUpMapByHexCode(String hexCode, int row, int col) {
+        String hexBinaryString = Integer.toBinaryString(Integer.decode(hexCode));
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < 8 - hexBinaryString.length()) {
+            sb.append('0');
+        }
+        sb.append(hexBinaryString);
+
+        char[] pixel = sb.reverse().toString().toCharArray();
+        for (int i = 0; i < 8; i++) {
+            map[row][col + i] = pixel[i] == '1';
+        }
+    }
+
+    static void callUnusableLine(BufferedReader br, int cnt) throws IOException {
+        while (cnt-- > 0) {
+            br.readLine();
+        }
+    }
+}


### PR DESCRIPTION
## [6580번 쿼드 트리](https://www.acmicpc.net/problem/6580)

### 1. 풀이
현재 문제의 핵심은 크게 두 가지라고 볼 수 있다. 차례대로 살펴보자.

##### 1) `0xff` 헥스코드 너 뭔데?
##### 2) 어떻게 작은 단위의 문제로 나눌 것인가?
---

#### 1) `0xff` 헥스코드 너는 뭐냐?
헥스(Hex). 말 그대로 16진수 표기법 중 하나라고 볼 수 있다. 중요한 것은 `0xff`에서 16진수를 나타내는 것은 뒤에 두 자리 수라는 점이다. 16진수는 문제에서 알려주듯이 아래의 문자들로 구성된다. `0xff` 표기법의 경우 뒤 두 자리수만을 16진수로 표기하는 것이므로, `11111111` 총 8자리 즉 8bit 정수를 표현할 수 있는 것이다.

```text
{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, a, b, c, d, e, f }
```

`0xff` 헥스코드의 경우 색좌표 추출 및 비트 연산에서 주로 다루게 되는데 Java에서는 아래와 같이 선언할 수도 있다. (~~사실 처음 알았다.~~)

```java
int foo = 0xff;
```
하지만 현재 문제에서는 String으로 해당 픽셀값들을 제공하고 있으므로, 변수에 다이렉트로 선언할 수가 없는 상황이다. 따라서 이를 decoding 해주는 작업이 필요한데, Java에서는 감사하게도 `decode` 함수를 통해 처리할 수 있다.

```java
// foo == 255
int foo = Integer.decode("0xff"); 
```

---
#### 2) 어떻게 작은 단위의 문제로 나눌 것인가?
문제의 input과 output이 괴랄해서 혼란스러울 수 있지만, 위 헥스코드만 잘 해독(?)해서 배열로 선언한다면 N x N 그리드 문제와 다를 것이 없다. 문제에서 주어진 예제를 '8 x 8' 그리드로 옮기면 아래와 같은 모습이다.

![image](https://user-images.githubusercontent.com/44356083/206891316-99ccb93a-9434-4733-8fe4-b481c22ea639.png)

그림을 통해 직관적으로 알 수 있듯이 `2^n` 길이의 격자로 나누었을 때, 내부의 비트가 모두 동일하다면 해당 비트를 반환하고 그렇지 않은 경우에는 `Q`를 붙여 내부 격자의 형태를 재정의한다.

이 개념을 풀이로 가지고 들어오면, 가장 큰 크기(N)에서 `1/2`로 나눠가면서 각 내부 그리드의 형태를 파악해 반환해주는 재귀함수를 구현하면 풀이할 수 있다.