### PR TITLE
[Gold 4] 10830번 행렬 제곱

### DIFF
--- a/src/divideNConquer/dnc_10830_matrixPower.java
+++ b/src/divideNConquer/dnc_10830_matrixPower.java
@@ -1,0 +1,72 @@
+package divideNConquer;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/10830
+ */
+public class dnc_10830_matrixPower {
+
+    static int[][] A;
+    static int N;
+
+    static int[][] divide(long exponent) {
+        if (exponent == 1L) {
+            return A;
+        }
+
+        if (exponent % 2 == 0) {
+            int[][] temp = divide(exponent / 2);
+            return multiply(temp, temp);
+        } else {
+            return multiply(divide(exponent - 1), A);
+        }
+    }
+
+    static int[][] multiply(int[][] a, int[][] b) {
+        int[][] ret = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < N; k++) {
+                    ret[i][j] += a[i][k] * b[k][j];
+                }
+                ret[i][j] %= 1000;
+            }
+        }
+        return ret;
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        long B = Long.parseLong(st.nextToken());
+
+        A = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                A[i][j] = Integer.parseInt(st.nextToken()) % 1000;
+            }
+        }
+
+        int[][] result = divide(B);
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                bw.write(result[i][j] + " ");
+            }
+            bw.write("\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## [10830번 행렬 제곱](https://www.acmicpc.net/problem/10830)

### 1. 풀이

행렬 곱셈의 경우 결합법칙이 적용된다는 점을 이용한다면, 분할정복으로 쉽게 풀이할 수 있다.

다만, 현재 문제에서의 핵심은 무작정 N/2로 나눠서 분할하는 것이 아닌, 홀수와 짝수일 때를 나누어서 처리한다면 보다 효율적인 연산과정을 만들어낼 수 있다. DP를 적용할 수도 있지만, 현재 문제에서는 B의 범위가 너무 크기때문에 DP로 메모이제이션을 사용할 경우 메모리 초과가 발생할 수 있다.

필자가 작성한 분할정복 게시글에 상세한 내용이 있으니 참고하자.
- [Blog - 분할정복](https://kwanik.tistory.com/17)