### PR TITLE
[Platinum 5] 1725번 히스토그램

### DIFF
--- a/src/simulation/sml_26772_poziomeSerca.java
+++ b/src/simulation/sml_26772_poziomeSerca.java
@@ -1,0 +1,44 @@
+package simulation;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+/**
+ * 1. 문제 링크:https://www.acmicpc.net/problem/26772
+ */
+public class sml_26772_poziomeSerca {
+
+    static final String[] LINES = {
+            " @@@   @@@ ",
+            "@   @ @   @",
+            "@    @    @",
+            "@         @",
+            " @       @ ",
+            "  @     @  ",
+            "   @   @   ",
+            "    @ @    ",
+            "     @     "
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        for (int i = 0, n = LINES.length; i < n; i++) {
+            for (int j = 0; j < N; j++) {
+                bw.write(LINES[i]);
+                if (j != N - 1) {
+                    bw.write(" ");
+                }
+            }
+            bw.write("\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/src/simulation/sml_27239_chessBoard.java
+++ b/src/simulation/sml_27239_chessBoard.java
@@ -1,0 +1,26 @@
+package simulation;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/27239
+ */
+public class sml_27239_chessBoard {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        int row = N / 8 + (N % 8 == 0 ? 0 : 1);
+        int col = N % 8 == 0 ? 8 : N % 8;
+
+        bw.write(((char) (col + 'a' - 1)) + "" + row);
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/src/stack/stack_01725_histogram.java
+++ b/src/stack/stack_01725_histogram.java
@@ -1,0 +1,42 @@
+package stack;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/1725
+ */
+public class stack_01725_histogram {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        int arr[] = new int[N + 2];
+        for(int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+
+        int ret = 0;
+        Stack<Integer> stack = new Stack<Integer>();
+        stack.push(0);
+        for(int i = 1; i <= N + 1; i++) {
+            while(!stack.isEmpty() && arr[stack.peek()] > arr[i]) {
+                int height = arr[stack.pop()];
+                int width = i - stack.peek() - 1;
+                ret = Math.max(ret, height * width);
+            }
+            stack.push(i);
+        }
+
+        bw.write(String.valueOf(ret));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+}


### PR DESCRIPTION
## [1725번 히스토그램](https://www.acmicpc.net/problem/1725)

### 1. 풀이
본 문제는 분할정복으로 풀이하는 것이 보다 직관적일 수 있으나, 스택으로 문제를 풀었기에 스택을 사용한 풀이법을 기재하고자 한다. 현재 블로그에 쓰고 있는 알고리즘 포스팅에서 분할정복의 차례가 왔을 때, 해당 문제를 다시 분할 정복으로 풀어보고자 한다.

문제를 Stack으로 접근했던 이유는, input으로 들어오는 막대기의 길이에 따라서 즉각적으로 만들 수 있는 형태의 직사각형이 달라지기 때문이다. 그렇다면 막대기의 길이에 따라 어떤 형태로 풀이를 진행할 것인지 고민이 필요하다.

- 기준점보다 긴 막대기가 들어왔는가?
- 기준점보다 짧은 막대기가 들어왔는가?
- 그럼 기준점을 어떻게 잡을 것인가?

먼저, 마지막 의문에 대한 답은 `Stack`의 탑을 기준으로 한다. 탑을 기준으로 했을 때, 길거나 같은 길이의 막대기가 들어온다면 `Stack`에 `push`를 하고, 짧은 막대기가 들어온다면 해당 막대기보다 짧은 막대기가 나올 때까지 `Stack`에서 `pop`을 하여 넓이를 산출한다.

왜 이렇게 풀이할 수 있는 것일까?

우선 현재 스택의 탑에 위치한 막대의 길이와 같거나 큰 막대가 들어온 경우, 넓은 직사각형을 만들 수 있는 보장이 생긴다. 이 과정에서 중요한 것은 항상 더 넓은 직사각형이 만들어지지는 않을 것이라는 점이다.

![image](https://user-images.githubusercontent.com/44356083/212578344-fc9cf491-c5d0-4d84-8c86-9111048807c6.png)
![image](https://user-images.githubusercontent.com/44356083/212578371-62521064-2908-41c9-bacb-e7d07079a1c1.png)

위 두 그림을 참고했을 때, 막대가 길어질 수록 넓은 표면적을 만들 수 있는 조건이 충족되지만, 중요한 것은 길이가 충분히 길지 않을 경우에는, 가로로 긴 직사각형을 만들 수 있음을 놓치면 안된다는 얘기다.

따라서 최대면적을 계산하는 과정을 통해 `Stack`에서 `pop`을 할 때, 길이가 줄어드는 경우에는 해당 막대만 `pop`을 함으로써 넓은 면적을 가질 수 있도록 처리하는 것이 중요하다.