### PR TITLE
Problem Solved: 14499번 주사위 굴리기

### DIFF
--- a/src/simulation/sml_14499_rollDice.java
+++ b/src/simulation/sml_14499_rollDice.java
@@ -1,0 +1,108 @@
+package simulation;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/14499
+ */
+public class sml_14499_rollDice {
+    static final int[] dy = {0, 0, -1, 1};
+    static final int[] dx = {1, -1, 0, 0};
+
+    static int N, M;
+    static int[][] map;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        int y = Integer.parseInt(st.nextToken());
+        int x = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        map = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        Dice dice = new Dice(y, x);
+
+        st = new StringTokenizer(br.readLine());
+        while (K-- > 0) {
+            dice.roll(Integer.parseInt(st.nextToken()) - 1);
+        }
+
+        System.out.print(dice.getMovement().trim());
+        br.close();
+    }
+
+    static class Dice {
+        int y, x;
+        int[] num = new int[6];
+        StringBuilder sb = new StringBuilder();
+
+        public Dice(int y, int x) {
+            this.y = y;
+            this.x = x;
+        }
+
+        void roll(int dir) {
+            int ny = y + dy[dir];
+            int nx = x + dx[dir];
+
+            if (ny < 0 || nx < 0 || N <= ny || M <= nx) return;
+
+            // 위, 동, 북, 서, 남, 밑
+            int tmp = num[0];
+            switch (dir) {
+                case 0: // 동
+                    num[0] = num[3];
+                    num[3] = num[5];
+                    num[5] = num[2];
+                    num[2] = tmp;
+                    break;
+                case 1: // 서
+                    num[0] = num[2];
+                    num[2] = num[5];
+                    num[5] = num[3];
+                    num[3] = tmp;
+                    break;
+                case 2: // 남
+                    num[0] = num[1];
+                    num[1] = num[5];
+                    num[5] = num[4];
+                    num[4] = tmp;
+                    break;
+                default: // 북
+                    num[0] = num[4];
+                    num[4] = num[5];
+                    num[5] = num[1];
+                    num[1] = tmp;
+            }
+
+            if (map[ny][nx] == 0) {
+                map[ny][nx] = num[5];
+            } else {
+                num[5] = map[ny][nx];
+                map[ny][nx] = 0;
+            }
+
+            y = ny;
+            x = nx;
+
+            sb.append(num[0]).append("\n");
+        }
+
+        String getMovement() {
+            return sb.toString();
+        }
+    }
+}


### PR DESCRIPTION
## [14499번 주사위 굴리기](https://www.acmicpc.net/problem/14499)

### 1. 풀이
구현 문제이지만 주사위를 굴리는 방법을 구현하는 과정에서 실수를 범하기 좋은 유형의 문제다. 하지만 문제는 꽤나 단순하게 접근할 수 있는데, 그 이유는 주사위 6면에 대해서는 1차원 배열로 선언이 가능하며 네 방위(동, 서, 남, 북)로 움직이는 행위만 잘 정의해주면 되기 때문이다. 따라서, 각 배열의 index에 대해 위치를 사전에 정의해두고, 이를 네 방면으로 굴렸을 때 인덱스가 어떻게 변하는지만 정리하여 구현하면 된다. 배열 index가 변하는 것은 아래 표를 참고하자

| case | 윗면 | 북쪽 | 동쪽 | 서쪽 | 남쪽 | 밑면 |
| ----- | ----- | ----- | ----- | ----- | ----- | ----- |
| origin | 0 | 1 | 2 | 3 | 4 | 5 |
| 동 | 3 | 1 | 0 | 5 | 4 | 2 |
| 서 | 2 | 1 | 5 | 0 | 4 | 3 |
| 남 | 1 | 5 | 2 | 3 | 0 | 4 |
| 북 | 4 | 0 | 2 | 3 | 5 | 1 |