### PR TITLE
[Silver 2] 10819번 차이를 최대로

### DIFF
--- a/src/backtracking/backtracking_10819_maxSubtract.java
+++ b/src/backtracking/backtracking_10819_maxSubtract.java
@@ -1,0 +1,50 @@
+package backtracking;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class backtracking_10819_maxSubtract {
+    static int N;
+    static int[] arr;
+    static boolean[] visit;
+    static int ans = -801;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        N = Integer.parseInt(br.readLine());
+
+        arr = new int[N];
+        visit = new boolean[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        backtracking(0, 0, -1);
+
+        bw.write(ans + "");
+        bw.close();
+        br.close();
+    }
+
+    static void backtracking(int sum, int cnt, int preIdx) {
+        if (cnt == N) {
+            ans = Math.max(ans, sum);
+            return;
+        }
+
+        for (int i = 0; i < N; i++) {
+            if (visit[i]) continue;
+
+            visit[i] = true;
+            if (preIdx != -1) {
+                backtracking(sum + Math.abs(arr[i] - arr[preIdx]), cnt + 1, i);
+            } else {
+                backtracking(sum, cnt + 1, i);
+            }
+            visit[i] = false;
+        }
+    }
+}


### PR DESCRIPTION
## [10819번 차이를 최대로](https://www.acmicpc.net/problem/10819)

### 1. 풀이
뭔가 수열의 순서를 변경하여 연속된 수들의 합을 구하는 수학적인 접근이 있을 것 같지만.... 귀찮기도 해서 그냥 백트래킹으로 풀었읍니다....

정수 배열의 범위가 최대 8로 8! 의 경우의 수만 해결해주면 되므로 중복되지 않는 순열을 만드는 기법을 이용해 합을 산정해주었다.