### PR TITLE
[Gold 4] 3190번 뱀

### DIFF
--- a/src/simulation/sml_03190_snake.java
+++ b/src/simulation/sml_03190_snake.java
@@ -1,0 +1,88 @@
+package simulation;
+
+import java.io.*;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/3190
+ */
+public class sml_03190_snake {
+    static final int APPLE = 1, SNAKE = 2;
+    static final int[] dy = {-1, 0, 1, 0};
+    static final int[] dx = {0, 1, 0, -1};
+    static int N;
+    static int[][] map;
+    static char[] query = new char[10001];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+
+        int K = Integer.parseInt(br.readLine());
+        while (K-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            map[Integer.parseInt(st.nextToken()) - 1][Integer.parseInt(st.nextToken()) - 1] = APPLE;
+        }
+
+        int L = Integer.parseInt(br.readLine());
+        while (L-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            query[Integer.parseInt(st.nextToken())] = st.nextToken().charAt(0);
+        }
+
+        Snake snake = new Snake();
+
+        bw.write(snake.moveAndGetTime() + "");
+        bw.close();
+        br.close();
+    }
+
+    static class Snake {
+        int dir = 1;
+        Deque<Integer> deque = new LinkedList<>();
+
+        public Snake() {
+            deque.add(0);
+            map[0][0] = SNAKE;
+        }
+
+        int moveAndGetTime() {
+            int time = 0;
+
+            while (true) {
+                time++;
+
+                int ny = deque.peekFirst() / N + dy[dir];
+                int nx = deque.peekFirst() % N + dx[dir];
+
+                if (ny < 0 || nx < 0 || N <= ny || N <= nx || map[ny][nx] == SNAKE) break;
+
+                if (map[ny][nx] == APPLE) {
+                    map[ny][nx] = SNAKE;
+                    deque.addFirst(ny * N + nx);
+                } else {
+                    map[ny][nx] = SNAKE;
+                    map[deque.peekLast() / N][deque.peekLast() % N] = 0;
+                    deque.pollLast();
+                    deque.addFirst(ny * N + nx);
+                }
+
+                if (time <= 10000 && (query[time] == 'L' || query[time] == 'D')) rotate(query[time]);
+            }
+
+            return time;
+        }
+
+        private void rotate(char type) {
+            dir = type == 'L'
+                    ? (dir + 3) % 4
+                    : (dir + 1) % 4;
+        }
+    }
+
+}


### PR DESCRIPTION
## [3190번 뱀](https://www.acmicpc.net/problem/3190)

### 1. 풀이
구현, 시뮬레이션 유형의 문제로, 우선 문제를 꼼꼼하게 이해하는 것이 무엇보다도 중요한 문제다. 뱀의 움직임은 크게 세 가지의 유형으로 분리해서 생각할 수 있다.

#### 1.1 더 움직일 수 없는 경우

지도에서 벗어나려 하거나 움직이고자 하는 칸에 뱀의 몸뚱이가 있는 경우 게임은 종료된다.

#### 1.2 사과를 먹는 경우

사과를 먹는 경우 몸 길이가 1 늘어난다. 문제에서는 복잡하게 설명하였으나, 다음칸으로 전진한 머리를 유지하고 꼬리는 삭제하지 않는다는 것은 길이가 1 늘어났다고 봐도 무방하다.

#### 1.3 사과를 먹지 않는 경우

'몸길이가 변하지 않는다'는 말이 오히려 혼선을 주는 것 같은데, 실질적으로는 한 칸 앞으로 이동한다고 받아들이는 것이 개인적으로는 이해하기 쉬웠다.

이 세 가지 유형을 추상화 해본다면 한 가지 공통점을 찾을 수 있게 되는데, 바로 뭐가 됐든 머리는 한 칸 앞으로 간다는 것이다. 다만 머리가 이동한 자리에 사과가 있는 경우에는 꼬리를 유지해서 길이를 늘려주고, 그렇지 않은 경우에는 꼬리를 제거함으로써 이동만 시킨다는 것이다.

즉, 데이터(뱀의 머리와 꼬리)의 입출력이 양 쪽 끝에서만 발생한다는 것이고 우리는 그에 가장 적합한 자료구조인 Deque를 이용해 구현하면 된다는 것을 알 수 있다.

이 때, 진행된 게임의 시간에 따라서 방향을 전환시켜주는 부분만 추가적으로 잘 구현해준다면 해결할 수 있다.