### PR TITLE
[Gold 5] 2225번 합분해

### DIFF
--- a/src/dp/dp_02225_sumDecomposition.java
+++ b/src/dp/dp_02225_sumDecomposition.java
@@ -1,0 +1,42 @@
+package dp;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+/**
+ * 1. 문제 링크: https://www.acmicpc.net/problem/2225
+ */
+public class dp_02225_sumDecomposition {
+
+    static final int MOD = 1000000000;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        dp = new int[N + 1][K + 1];
+        for (int i = 1; i <= N; i++) {
+            for (int j = 1; j <= K; j++) {
+                if (j == 1) {
+                    dp[i][j] = 1;
+                } else if (i == 1) {
+                    dp[i][j] = j;
+                } else {
+                    dp[i][j] = (dp[i - 1][j] + dp[i][j - 1]) % MOD;
+                }
+            }
+        }
+
+        bw.write(dp[N][K] + "");
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## [2225번 합분해](https://www.acmicpc.net/problem/2225)

### 1. 풀이
2차원 DP형태의 문제라 직관적으로 해답을 떠올리기 다소 어려운 유형의 문제라고 할 수 있다. 직관적이지 않은 유형의 문제이므로 점화식을 한 번 도출해보도록 하자.

숫자 N을 정수 K개의 조합으로 만들 수 있는 문제를 다시 재조합하면 아래와 같이 생각할 수도 있다. dp[N][K]는 N을 K개 조합으로 만드는 경우의 수이고, 예시로 N = 6이고 K = 4라고 가정해보자.

`_ _ _ L` 네 자리에서 마지막 자리를 L(0 <= L <= 6)이라고 결정지었다고 생각해본다면, 다음과 같은 경우의 수가 나온다.

- dp[0][3]
- dp[1][3]
- dp[2][3]
- dp[3][3]
- dp[4][3]
- dp[5][3]
- dp[6][3]

마지막 자리 수(L)를 N에서 뺀 값(`N - L`)을 `K - 1`개의 조합으로 만드는 방식을 의미한다. 마지막 자리인 L이 모두 서로 다른 숫자여서 모든 경우의 수가 서로 다른 경우의 수를 만들고 있음이 보장되므로, 위 케이스들을 모두 더해주면 되는 것이다. 이를 점화식으로 풀어서 해결하면 풀린다!